### PR TITLE
The client now tries to fetch Steam Workshop mods if inserted into a Steam copy of the game.

### DIFF
--- a/source/game/main/initialization.cpp
+++ b/source/game/main/initialization.cpp
@@ -347,6 +347,7 @@ bool initGlobal(bool loadGraphics, bool createWindow) {
 	print("Registering mods");
 	devices.mods.registerDirectory("mods");
 	devices.mods.registerDirectory(getProfileRoot() + "mods");
+	devices.mods.registerDirectory("../../workshop/content/282590");
 
 	//Shortcut for the scene tree
 	if(devices.render)


### PR DESCRIPTION
This would allow the OS client to become a common replacement for the Steam client, which would help debugging... and I'm repeating my forum arguments...