### PR TITLE
added easier linux builds using vagrant

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ Afterward, run the `StarRuler2.sh` shell script to start the game.
 
 Several dependencies are required to build on linux, including libpng, zlib,
 GLEW, GLU, freetype2, libvorbisfile, libvorbis, libogg, libopenal, libbz2,
-libXRandR, and libcurl.
+libXRandR, and libcurl. If your distro does not package suiable versions of each
+dependency, this project includes a Vagrantfile that can build Star Ruler 2 out
+of the box.
 
 
 ## Differences with Commercial Version

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,31 @@
+script = "
+sudo yum install -y make
+sudo yum install -y cmake
+sudo yum install -y zlib-devel
+sudo yum install -y glew-devel
+sudo yum install -y freetype-devel
+sudo yum install -y libvorbis
+sudo yum install -y libvorbis-devel
+sudo yum install -y libogg-devel
+sudo yum install -y openal-soft-devel
+sudo yum install -y bzip2-devel
+sudo yum install -y libXrandr-devel
+sudo yum install -y gcc
+sudo yum install -y gcc-c++
+sudo yum install -y libpng-devel
+sudo yum install -y libcurl-devel
+sudo yum install -y libXi-devel
+echo 'To build:
+    cd /vagrant && make -f source/linux/Makefile compile
+
+After building, run the game with `bash StarRuler2.sh`' > /etc/motd
+"
+
+Vagrant.configure("2") do |config|
+  config.vm.synced_folder ".", "/vagrant"
+
+  config.vm.define "fedora-build" do |node|
+    node.vm.box = "generic/fedora28"
+    node.vm.provision "shell", inline: script
+  end
+end


### PR DESCRIPTION
Some distros don't package recent enough versions of dependencies to build this without a lot of manual work. Fedora happens to have all the right dependencies though, and the game still works if you copy it off the VM to another computer.