### PR TITLE
source/game/obj/object.h: don't complain about int overflow

### DIFF
--- a/source/game/obj/object.h
+++ b/source/game/obj/object.h
@@ -16,7 +16,7 @@
 #endif
 
 const unsigned ObjectTypeBitOffset = 26;
-const unsigned ObjectTypeMask = (unsigned)(0xFF << ObjectTypeBitOffset);
+const unsigned ObjectTypeMask = 0xFFU << ObjectTypeBitOffset;
 const unsigned ObjectIDMask = 0xFFFFFFFF >> (32 - ObjectTypeBitOffset);
 extern unsigned ObjectTypeCount;
 


### PR DESCRIPTION
./source/game/obj/object.h:19:49: warning: result of ‘(255 << 26)’ requires 35 bits to represent, but ‘int’ only has 32 bits [-Wshift-overflow=]
 const unsigned ObjectTypeMask = (unsigned)(0xFF << ObjectTypeBitOffset);
                                            ~~~~~^~~~~~~~~~~~~~~~~~~~~~