### PR TITLE
Fix for "front() called on empty vector" Errors on debug builds.

### DIFF
--- a/source/game/design/design.cpp
+++ b/source/game/design/design.cpp
@@ -824,7 +824,7 @@ Design::Design(SaveFile& file) : initialized(true), data(nullptr), clientData(nu
 
 	unsigned hexesCount = file;
 	hexes.resize(hexesCount);
-	file.read(&hexes.front(), sizeof(vec2u) * hexesCount);
+	file.read(hexes.data(), sizeof(vec2u) * hexesCount);
 
 	cropMin = vec2u(grid.width, grid.height);
 	cropMax = vec2u(0, 0);
@@ -948,7 +948,7 @@ void Design::save(SaveFile& file) const {
 	file.write(hexStatusIndex.data, sizeof(int) * hexStatusIndex.width * hexStatusIndex.height);
 
 	file << (unsigned)hexes.size();
-	file.write(&hexes.front(), sizeof(vec2u) * (unsigned)hexes.size());
+	file.write(hexes.data(), sizeof(vec2u) * (unsigned)hexes.size());
 
 	unsigned cnt = getShipVariableCount();
 	file << cnt;

--- a/source/game/design/subsystem.cpp
+++ b/source/game/design/subsystem.cpp
@@ -3646,7 +3646,7 @@ void Subsystem::init(SaveFile& file) {
 
 	unsigned hexCount = file;
 	hexes.resize(hexCount);
-	file.read(&hexes.front(), hexes.size() * sizeof(vec2u));
+	file.read(hexes.data(), hexes.size() * sizeof(vec2u));
 	hexEffects.resize(hexCount);
 
 	if(file >= SFV_0010) {
@@ -3799,7 +3799,7 @@ void Subsystem::save(SaveFile& file) const {
 	file << dataOffset;
 
 	file << unsigned(hexes.size());
-	file.write(&hexes.front(), hexes.size() * sizeof(vec2u));
+	file.write(hexes.data(), hexes.size() * sizeof(vec2u));
 
 	for(unsigned i = 0; i < hexes.size(); ++i) {
 		file << (unsigned)hexEffects[i].size();

--- a/source/game/render/bmf_loader.cpp
+++ b/source/game/render/bmf_loader.cpp
@@ -92,7 +92,7 @@ void loadBinaryMesh(const char* filename, Mesh& mesh) {
 		return;
 
 	vertices.resize(count);
-	file.read((char*)&vertices.front(), sizeof(vec3f) * count);
+	file.read((char*)vertices.data(), sizeof(vec3f) * count);
 
 	//Normals
 	file.read((char*)&count, sizeof(count));
@@ -100,7 +100,7 @@ void loadBinaryMesh(const char* filename, Mesh& mesh) {
 		return;
 
 	normals.resize(count);
-	file.read((char*)&normals.front(), sizeof(vec3f) * count);
+	file.read((char*)normals.data(), sizeof(vec3f) * count);
 
 	//UVs
 	file.read((char*)&count, sizeof(count));
@@ -108,7 +108,7 @@ void loadBinaryMesh(const char* filename, Mesh& mesh) {
 		return;
 
 	uvs.resize(count);
-	file.read((char*)&uvs.front(), sizeof(UV) * count);
+	file.read((char*)uvs.data(), sizeof(UV) * count);
 
 	//Faces
 	file.read((char*)&count, sizeof(count));

--- a/source/game/render/gl_vertexBuffer.cpp
+++ b/source/game/render/gl_vertexBuffer.cpp
@@ -237,7 +237,7 @@ namespace render {
 		bufferFlushes += 1;
 		vbFlushCounts[reason] += 1;
 
-		RenderStep* pSteps = &steps.front();
+		RenderStep* pSteps = steps.data();
 		for(unsigned i = 0, cnt = (unsigned)steps.size(); i < cnt; ++i) {
 			auto& step = pSteps[i];
 			shaderUniforms = step.shaderCache;


### PR DESCRIPTION
Instead of using $vector.front() which fails on empty vectors, we're now using the C++11 vector.data() to fetch the proper pointer
- the former fails silently in release builds but prevents debugging in most cases because of the standard setting _ITERATOR_DEBUG_LEVEL=2