### PR TITLE
Fix loading mods from the profile directory

### DIFF
--- a/source/game/main/initialization.cpp
+++ b/source/game/main/initialization.cpp
@@ -346,7 +346,7 @@ bool initGlobal(bool loadGraphics, bool createWindow) {
 	//Add mod sources
 	print("Registering mods");
 	devices.mods.registerDirectory("mods");
-	devices.mods.registerDirectory(getProfileRoot() + "mods");
+	devices.mods.registerDirectory(path_join(getProfileRoot(), "mods"));
 	devices.mods.registerDirectory("../../workshop/content/282590");
 
 	//Shortcut for the scene tree


### PR DESCRIPTION
Previously mods would try to be loaded from ~/.starruler2mods instead of ~/.starruler2/mods, which is outside of the profile directory, causing a script exception and then a game assert to trigger when mods are installed there (tested with Rising Stars).